### PR TITLE
Feature/#46 Homepage social media buttons / bootstrap improvements

### DIFF
--- a/website/src/Home.scss
+++ b/website/src/Home.scss
@@ -92,29 +92,6 @@
         margin: 0px;
     }
 
-    /* Full logo sizing for different screen widths. */
-    img#logo-full {
-        width: 50%;
-    }
-
-    @media (min-width:680px) {
-        img#logo-full {
-            width: 40%;
-        }
-    }
-
-    @media (min-width:1111px) {
-        img#logo-full {
-            width: 30%;
-        }
-    }
-
-    @media (min-width:1700px) {
-        img#logo-full {
-            width: 25%;
-        }
-    }
-
     #progress-container .row:not(:last-child) {
         margin-bottom: 25px;
     }

--- a/website/src/Home.tsx
+++ b/website/src/Home.tsx
@@ -105,30 +105,29 @@ const Home: React.FC = () => {
     return (
         <div id="Home">
             <div className="container-fluid" style={{ height: "fit-content", maxHeight: 800 }}>
-                <div className="row">
-                    <div className="col">
-                        {/* <h1>PS2 Icon Open Database</h1> */}
-                        <img id="logo-full" src="/images/logo-full.svg" alt="PS2IODB Full Logo" width="30%" style={{ marginLeft: '50%', transform:'translateX(-50%)' }}/>
+                <div className="row justify-content-center">
+                    <div className="col-8 col-md-6 col-lg-5 col-xl-4">
+                        <img id="logo-full" src="/images/logo-full.svg" width="100%" alt="PS2IODB Full Logo"/>
                     </div>
                 </div>
                 <div className="row justify-content-center">
-                    <div className="col-8 col-xl-6">
-                        <h5 className="p-3" style={{ textAlign: 'center' }}>
-                            Welcome to the PS2 Icons Open Database (PS2IODB), a crowdsourced collection of PlayStation 2 save game icons
-                        </h5>
+                    <div className="col-10 col-md-7 col-xl-5 col-xxl-4">
+                        <p className="p-3" style={{ textAlign: 'center' }}>
+                            Welcome to the PS2 Icons Open Database (PS2IODB), a crowdsourced collection of PlayStation 2 save game icons.
+                        </p>
                     </div>
                 </div>
                 <div className="row justify-content-center">
-                    <div className="col-5 col-md-3 px-1 py-1">
+                    <div className="col-5 col-md-3 col-xxl-2 px-1 py-1">
                         <Link className="btn btn-primary" to="/faq">FAQ</Link>
                     </div>
-                    <div className="col-5 col-md-3 px-1 py-1">
+                    <div className="col-5 col-md-3 col-xxl-2 px-1 py-1">
                         <Link className="btn btn-primary" to="/contribute">
                             <span className="d-none d-sm-inline">How to Contribute</span>
                             <span className="d-inline d-sm-none">Contribute</span>  {/* Shorten text at XS size. */}
                         </Link>
                     </div>
-                    <div className="col-10 col-md-3 px-1 py-1">
+                    <div className="col-10 col-md-3 col-xxl-2 px-1 py-1">
                         <div className="btn-group">
                             <Link type="button" className="btn btn-secondary" to="https://github.com/Issung/PS2IODB">
                                 <img src="https://www.svgrepo.com/show/512317/github-142.svg" alt="GitHub logo"/>

--- a/website/src/index.tsx
+++ b/website/src/index.tsx
@@ -13,11 +13,12 @@ const root = ReactDOM.createRoot(
 );
 root.render(
     <React.StrictMode>
-        <p className="size-indicator xs d-block d-sm-none">[XS] SM MD LG XL</p>
-        <p className="size-indicator sm d-none d-sm-block d-md-none">XS [SM] MD LG XL</p>
-        <p className="size-indicator md d-none d-md-block d-lg-none">XS SM [MD] LG XL</p>
-        <p className="size-indicator lg d-none d-lg-block d-xl-none">XS SM MD [LG] XL</p>
-        <p className="size-indicator d-none d-xl-block">XS SM MD LG [XL]</p>
+        <p className="size-indicator xs d-block d-sm-none">[XS] SM MD LG XL XXL</p>
+        <p className="size-indicator sm d-none d-sm-block d-md-none">XS [SM] MD LG XL XXL</p>
+        <p className="size-indicator md d-none d-md-block d-lg-none">XS SM [MD] LG XL XXL</p>
+        <p className="size-indicator lg d-none d-lg-block d-xl-none">XS SM MD [LG] XL XXL</p>
+        <p className="size-indicator xl d-none d-xl-block d-xxl-none">XS SM MD LG [XL] XXL</p>
+        <p className="size-indicator xxl d-none d-xxl-block">XS SM MD LG XL [XXL]</p>
         <App />
     </React.StrictMode>
 );


### PR DESCRIPTION
Add split button on homepage for github/discord/twitter.
On smaller screens the buttons now have FAQ and Contribute next to eachother and the split socials button underneath at full width.
Other improvements to code for the full size logo and subtitle text.